### PR TITLE
Absorption correction fix

### DIFF
--- a/total_scattering/file_handling/load.py
+++ b/total_scattering/file_handling/load.py
@@ -142,8 +142,8 @@ def create_absorption_wksp(filename, abs_method, geometry, material,
         if "AlignAndFocusArgs" in align_and_focus_args:
             input_wl = align_and_focus_args["AlignAndFocusArgs"]
             if "TMin" and "TMax" in input_wl:
-                props["wavelength_min"] = input_wl["TMin"]
-                props["wavelength_max"] = input_wl["TMax"]
+                props["tof_min"] = input_wl["TMin"]
+                props["tof_max"] = input_wl["TMax"]
 
         # But set wavelength max from logs if not set in JSON or elsewhere
         else:

--- a/total_scattering/reduction/total_scattering_reduction.py
+++ b/total_scattering/reduction/total_scattering_reduction.py
@@ -522,7 +522,7 @@ def TotalScatteringReduction(config=None):
         van.get('InelasticCorrection', None))
 
     # Warn about having absorption correction and multiple scat correction set
-    if van_abs_corr and van_ms_corr:
+    if van_abs_corr["Type"] and van_ms_corr["Type"]:
         log.warning(MS_AND_ABS_CORR_WARNING)
 
     # Compute the absorption correction for the vanadium if provided


### PR DESCRIPTION
Fixes an issue with the absorption correction donor workspace where the wavelength range was set to TOF values from the input json file. This caused the absorption correction to be calculated over a large wavelength range which resulted in 0 for all absorption correction types. 

Instead, the TOF min and max properties need to be set so that the wavelength gets calculated properly inside the `absorptioncorrutils.create_absorption_input` function.

Refer to gitlab defect [PD173](https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/173).