### PR TITLE
Fix failing absorption correction unit test

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,6 +9,9 @@ on:
       - '*'
     tags:
       - 'v*'
+  pull_request:
+    types: [ opened, edited, reopened, review_requested ]
+    branches: [ master ] 
 
 jobs:
   linux:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,8 +10,8 @@ on:
     tags:
       - 'v*'
   pull_request:
-    types: [ opened, edited, reopened, review_requested ]
-    branches: [ master ] 
+    branches:
+      - '*'
 
 jobs:
   linux:

--- a/total_scattering/file_handling/load.py
+++ b/total_scattering/file_handling/load.py
@@ -152,7 +152,7 @@ def create_absorption_wksp(filename, abs_method, geometry, material,
                 "lambda",
                 "skf12.lambda",
                 "BL1B:Det:TH:BL:Lambda",
-                "freq"]
+                "frequency"]
 
             for logname_wl in wl_lognames:
                 run = abs_input.run()


### PR DESCRIPTION
Changes the log name used in the donor function to be the correct log name. This was causing the `test_load_with_abscorr` test to fail since 'freq' was a single value log - 'frequency' should be used instead as it is a time series log.

Fixes #87 