### PR TITLE
Autogrouping

### DIFF
--- a/tests/total_scattering/autogrouping/test_similarity.py
+++ b/tests/total_scattering/autogrouping/test_similarity.py
@@ -1,0 +1,105 @@
+# test it
+import unittest
+import numpy
+import total_scattering.autogrouping.similarity as similarity
+
+class test_similarity( unittest.TestCase ):
+
+  # return r'th component of a triangle weight function extending L indices in each direction
+  # from the "origin". Add 1 to L to account for the zero-offset ( r == 0 ) weight value
+  def weight_triangular( self, r, L ):
+
+    return ( L - abs( r ) + 1 ) / ( L + 1 )
+  
+  '''
+  Weighted cross correlation of vectors within a small window:
+  sum_over_r( weight[ r ] * sum_over_x ( f( x ) * g( x + r ) ) ) for r in
+  union([ 0, L ] and [ 0, -L ] ), inclusive. By default, the weight function
+  is the triangular weight function defined above. Tested with a known analytic
+  solution calculated using numpy functions
+  '''
+  def test_weighted_cross_corr( self ):
+
+    # Arbitrary vectors
+    f = [ 1, 3, 5, 7, 11, 13, 15, 17 ]
+    g = [ 2, 4, 6, 8, 10, 12, 14, 16 ]
+
+    # Ensure that each component of f and g contributes to the result 
+    L = len( f ) - 1
+
+    weights = [ self.weight_triangular( r, L ) for r in range( -L, L + 1 ) ]
+
+    # Numpy expects the vectors in the reverse order
+    ncc = numpy.correlate( g, f, mode = 'full' )
+
+    # Element-wise multiply to apply the weights:
+    weighted_ncc = weights * ncc
+
+    # Sum to get non-normalized similarity measure:
+    gold = numpy.sum( weighted_ncc )
+
+    # Calculate using the method under test:
+    metric = similarity.similarity_metric( L )
+
+    test = metric.triangular_weighted_cross_correlation( f, g )
+
+    self.assertEqual( gold, test )
+
+  '''
+  Test the normalized similarity meausure built from the weighted cross correlation.
+  It should be:
+  commutative: similarity( f, g ) = similarity( g, f )
+  unity for auto-similarity: similarity( f, f ) = 1
+  indicate similarity: similarity( f, h ) > similarity( g, h ) ---> f and h are more similar
+  '''
+  def test_de_gelder_similarity( self ):
+
+    # instantiate similarity object
+    metric = similarity.similarity_metric()
+
+    # the metric should return unity for perfect correlation
+    f = [ 1, 2, 3, 4, 5, 6, 7, 8 ]
+
+    metric_value = metric.de_gelder_similarity( f, f )
+
+    self.assertEqual( metric_value, 1 )
+
+    # since it is a normalized metric, it should be invariant to scaling.
+    # it should also be commutative
+    f = [ 1, 3, 5, 7, 11, 13 ]
+
+    g = [ 2, 4, 6, 8, 10, 12 ]
+
+    scale_factor = 5
+
+    self.assertEqual( metric.de_gelder_similarity( scale_factor * f, scale_factor * g ), \
+                      metric.de_gelder_similarity( scale_factor * g, scale_factor * f ) )
+
+    # The metric should indicate similarity. This vector should be more similar to f than g
+    h = [ x - 0.1 for x in f ]
+    fh = metric.de_gelder_similarity( f, h )
+    fg = metric.de_gelder_similarity( f, g )
+
+    self.assertGreater( fh, fg )
+
+  '''
+  test equality via a known analytic solution
+  '''
+  def test_pointwise_squared_difference_similarity( self ):
+
+    # instantiate similarity object
+    metric = similarity.similarity_metric()
+
+    diff = 2
+
+    f = [ 1, 2, 3, 4, 5, 6, 7, 8 ]
+    g = [ x + diff for x in f ]
+
+    squared_diff_sum = metric.pointwise_squared_difference_similarity( f, g )
+
+    gold = 1 - len( f ) * diff ** 2
+
+    self.assertEqual( squared_diff_sum, gold )
+
+if __name__ == '__main__':
+  unittest.main()

--- a/total_scattering/autogrouping/autogrouping.py
+++ b/total_scattering/autogrouping/autogrouping.py
@@ -1,0 +1,97 @@
+import json
+import numpy as np
+
+from mantid.dataobjects import \
+    EventWorkspace, \
+    MaskWorkspace
+from mantid.simpleapi import \
+    Load
+
+
+def similarity_matrix_crosscorr(wksp: EventWorkspace, mask_wksp: MaskWorkspace):
+    return
+
+
+def similarity_matrix_degelder(wksp: EventWorkspace, mask_wksp: MaskWorkspace):
+    return
+
+
+def euclidean_distance(wksp: EventWorkspace, mask_wksp: MaskWorkspace,
+                       threshold: float):
+    return
+
+
+def get_key(key, config):
+    '''Returns the value of key in config. Raises error if not found.'''
+    value = config.get(key, None)
+    if value is None:
+        raise RuntimeError("Expected '{}' to be set in inputs".format(key))
+    return value
+
+
+def get_grouping_method(grouping):
+    '''Make sure grouping is one of the supported options'''
+    method = grouping.split("_")
+    clusterings = ["DBSCAN", "KMEANS"]
+    methods = ["DG", "CC", "ED"]
+
+    if len(method) == 2 and method[0] in clusterings and method[1] in methods:
+        return method
+    else:
+        raise ValueError("Invalid grouping method")
+
+
+def Autogrouping(config):
+
+    diamond_file = get_key("DiamondFile", config)
+    masking_file = get_key("MaskFile", config)
+
+    grouping_method = get_key("GroupingMethod", config)
+    method = get_grouping_method(grouping_method)
+
+    num_groups = get_key("NumberOutputGroups", config)
+    threshold = get_key("Threshold", config)
+
+    output_file = get_key("OutputGroupingFile", config)
+    output_mask = get_key("OutputMaskFile", config)
+
+    wksp = Load(Filename=diamond_file)
+    mask_wksp = Load(Filename=masking_file)
+
+    if method[1] == "DG":
+        # Compute the deGelder similarity matrix
+        grouping = similarity_matrix_degelder(wksp, mask_wksp)
+    elif method[1] == "CC":
+        # Compute the cross-correlation
+        grouping = similarity_matrix_crosscorr(wksp, mask_wksp)
+    elif method[1] == "ED":
+        # Compute the euclidean distance
+        grouping = euclidean_distance(wksp, mask_wksp, threshold)
+
+    # TODO:
+    # Pass result to clustering algorithm
+    # Convert to grouping workspace
+    # Output grouping file
+
+    return
+
+
+def main(config=None):
+
+    # Read in JSON if not provided to main()
+    if not config:
+        import argparse
+        parser = argparse.ArgumentParser(
+            description="Absolute normalization PDF generation")
+        parser.add_argument('json', help='Input json file')
+        options = parser.parse_args()
+        print("loading config from '%s'" % options.json)
+        with open(options.json, 'r') as handle:
+            config = json.load(handle)
+
+    # Run total scattering reduction
+    Autogrouping(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/total_scattering/autogrouping/similarity.py
+++ b/total_scattering/autogrouping/similarity.py
@@ -1,0 +1,85 @@
+# code it
+# Bundle all of this into a class, rename it something better
+import numpy
+
+'''
+This file calculates similarity metrics for numpy vectors.
+It is build from cross correlations
+'''
+
+class similarity_metric:
+
+  def __init__( self, L = 5 ):
+
+    self.L = L
+    self.weights = [ self.weight_triangular( r ) for r in range( 0, self.L + 1 ) ]
+
+  '''
+  symmetric weight function
+  '''
+  def weight_triangular( self, r ):
+
+    return ( self.L - abs( r ) + 1 ) / ( self.L + 1 )
+
+  '''
+  f, g ---> vectors to cross correlate.
+
+  L ---> From their initial aligned positions, vectors will be cross correlated at
+         offsets in union([ 0, L ] and [ 0, -L ] ), inclusive.
+
+  weights ---> weight[ i ] to be applied to cross_correlation[ i ] for i in [ -L, L ] inclusive
+
+  returns ---> weighted cross correlation of the vectors:
+               
+               sum_over_r( weight[ r ] * sum_over_x ( f( x ) * g( x + r ) ) )
+  '''
+  def triangular_weighted_cross_correlation( self, f, g ):
+
+    if( len( f ) != len( g ) ):
+
+      raise RuntimeError( "weighted_cross_correlation expects equal length vectors" )
+
+    # Calculate sum at r = 0
+    weighted_sum = numpy.dot( f, g )
+
+    for r in range( 1, self.L + 1 ):
+
+      positive_sub_sum = numpy.dot( f[ : -r ], g[ r : ] )
+
+      negative_sub_sum = numpy.dot( f[ r: ], g[ : -r ] )
+
+      weighted_sum += ( self.weights[ r ] * ( positive_sub_sum + negative_sub_sum ) )
+
+    return weighted_sum
+
+  '''
+  normalize the triangular weighted cross correlation to provide a pairwise similarity metric
+
+  abs( metric ) <= 1
+  '''
+  def de_gelder_similarity( self, f, g ):
+
+    weighted_cross_correlation = \
+    self.triangular_weighted_cross_correlation( f, g )
+
+    g_norm_component = \
+    self.triangular_weighted_cross_correlation( g, g )
+
+    f_norm_component = \
+    self.triangular_weighted_cross_correlation( f, f )
+
+    normalization = numpy.sqrt( g_norm_component * f_norm_component )
+
+    return weighted_cross_correlation / normalization
+
+
+  '''
+  a very simple similarity metric
+  '''
+  def pointwise_squared_difference_similarity( self, f, g ):
+
+    if( len( f ) != len( g ) ):
+
+      raise RuntimeError( "weighted_cross_correlation expects equal length vectors" )
+
+    return 1 - numpy.sum( numpy.square( numpy.subtract( f, g ) ) )


### PR DESCRIPTION
Calculate de Gelder and pointwise squared difference similarity measures for equal length vectors.

Linked story ---> https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/229
Linked task ---> https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/249
Linked task ---> https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/250

Linked paper ---> https://onlinelibrary.wiley.com/doi/10.1002/1096-987X(200102)22:3%3C273::AID-JCC1001%3E3.0.CO;2-0
Linked paper ---> https://aip.scitation.org/doi/10.1063/1.5034782

To test:
`cd tests/total_scattering/autogrouping`
`python -m pytest test_similarity.py`