### PR TITLE
Adds the workflow_dispatch to add manual CI triggering

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -4,6 +4,11 @@ env:
   PYTHON_MAIN_VERSION: 3.7
 
 on:
+  workflow_dispatch:
+    branches:
+      - '*'
+    tags:
+      - 'v*'
   push:
     branches:
       - '*'


### PR DESCRIPTION
This is to add the capability to do ["Manually running workflows"](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow)

NOTE: This option won't be available in the UI until after it is merged into the "default branch" (`next` for this project)