### PR TITLE
Add resonance filtering support for NOMAD

### DIFF
--- a/examples/sns/nomad_ResonanceFilter.json
+++ b/examples/sns/nomad_ResonanceFilter.json
@@ -1,0 +1,37 @@
+{
+    "Facility": "SNS",
+    "Instrument": "NOM",
+    "Title" : "ceriaDP375_PAC06_at_300K_IDL_Calib",
+    "Sample": { "Runs" : "143157",
+             "Background" : { "Runs" : "143230",
+                              "Background" : { "Runs" : "143074" }
+                            },
+             "Material" : "Ce0.85 Y0.15 O2",
+             "MassDensity" : 6.89,
+             "PackingFraction" : 0.70,
+             "Geometry" : {"Radius" : 0.3,
+                           "Height" : 1.8 },
+             "AbsorptionCorrection" : { "Type" : "SampleOnly" }
+            },
+    "Normalization": { "Runs" : "143080",
+                  "Background" : { "Runs" : "14307"},
+                  "Material" : "V",
+                  "MassDensity" : 6.11,
+                  "PackingFraction" : 1.0,
+                  "Geometry" : {"Radius" : 0.2925,
+                                "Height" : 1.8 },
+                  "AbsorptionCorrection" : { "Type" : "SampleOnly" }
+                },
+    "Calibration":{"Filename":"/SNS/users/y8z/Data/Igor_Ceria_New/shared/NOM_calibrate_d143068_2020_02_11.h5"},
+    "AlignAndFocusArgs" : { "TMin" : 300.0, "TMax" : 16667.0 },
+    "HighQLinearFitRange" : 0.60,
+    "Merging":{"QBinning": [0.0, 0.005, 40.0],
+               "SumBanks": [3]
+              },
+    "ResonanceFilter": {"Axis": "Energy",
+                        "LowerLimits" : [0.5, 1.0, 4.5],
+                        "UpperLimits" : [0.9, 1.5, 6.0]
+                       },
+    "CacheDir" : "./tmp",
+    "OutputDir" : "./output"
+}

--- a/total_scattering/reduction/total_scattering_reduction.py
+++ b/total_scattering/reduction/total_scattering_reduction.py
@@ -408,6 +408,13 @@ def TotalScatteringReduction(config=None):
     binning = merging['QBinning']
     characterizations = merging.get('Characterizations', None)
 
+    # Get Resonance filter configuration
+    res_filter = config.get('ResonanceFilter', None)
+    if res_filter is not None:
+        res_filter_axis = res_filter.get('Axis', None)
+        res_filter_lower = res_filter.get('LowerLimits', None)
+        res_filter_upper = res_filter.get('UpperLimits', None)
+
     # Grouping
     grouping = merging.get('Grouping', None)
     cache_dir = config.get("CacheDir", os.path.abspath('.'))
@@ -546,6 +553,13 @@ def TotalScatteringReduction(config=None):
     alignAndFocusArgs['PreserveEvents'] = False
     alignAndFocusArgs['MaxChunkSize'] = 8
     alignAndFocusArgs['CacheDir'] = os.path.abspath(cache_dir)
+    # add resonance filter related properties
+    # NOTE:
+    #    the default behaivor is no filtering if not specified.
+    if res_filter is not None:
+        alignAndFocusArgs['ResonanceFilterAxis'] = res_filter_axis
+        alignAndFocusArgs['LowerLimits'] = res_filter_lower
+        alignAndFocusArgs['UpperLimits'] = res_filter_upper
 
     # Get any additional AlignAndFocusArgs from JSON input
     if "AlignAndFocusArgs" in config:


### PR DESCRIPTION
- Original Gitlab user story: [PD59](https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/59)

This PR introduces the support of resonance filtering when processing data from NOMAD.
The implementation is done inside `mantid`, and the changes here are related to parsing the input configuration file (json).
An example json file for using this resonance filtering feature is also added in this PR.