### PR TITLE
patching for self-scattering level checking

### DIFF
--- a/tests/total_scattering/test_normalizations.py
+++ b/tests/total_scattering/test_normalizations.py
@@ -38,8 +38,8 @@ class TestMaterial(unittest.TestCase):
 
     def test_properties(self):
         m = Material(self.s_of_q)
-        self.assertAlmostEqual(m.bcoh_avg_sqrd, 31.669, places=3)
-        self.assertAlmostEqual(m.btot_sqrd_avg, 32.144, places=3)
+        self.assertAlmostEqual(m.bcoh_avg_sqrd, 0.31669, places=3)
+        self.assertAlmostEqual(m.btot_sqrd_avg, 0.32144, places=3)
         self.assertAlmostEqual(m.laue_monotonic_diffuse_scat, 1.015, places=3)
 
 

--- a/tests/total_scattering/test_normalizations.py
+++ b/tests/total_scattering/test_normalizations.py
@@ -80,15 +80,12 @@ class TestNormalizations(unittest.TestCase):
         s_q_norm, bad_fits = calculate_and_apply_fitted_levels(self.s_of_q,
                                                                q_ranges)
         # bank 2 will have a negative offset for the given range
-        self.assertEqual(len(bad_fits), 1)
-        self.assertIn(2, bad_fits)
-        self.assertAlmostEqual(bad_fits[2], -0.4079, places=3)
-        # since bank 2 was negative, it won't get scaled (same as offset=1.0)
-        offsets = {2: 1.0, 3: 0.58826, 4: 0.74313, 5: 0.79304}
+        self.assertEqual(len(bad_fits), 0)
+        offsets = {2: -0.4079, 3: 0.58826, 4: 0.74313, 5: 0.79304}
         for key in q_ranges:
             norm_y = s_q_norm.readY(key - 1)
             bank_y = self.s_of_q.readY(key - 1)
-            self.assertTrue(np.allclose(norm_y * offsets[key], bank_y,
+            self.assertTrue(np.allclose(norm_y * (1.0 - offsets[key]), bank_y,
                                         rtol=1e-3, equal_nan=True))
 
     def test_to_f_of_q(self):

--- a/total_scattering/reduction/normalizations.py
+++ b/total_scattering/reduction/normalizations.py
@@ -122,7 +122,8 @@ def calculate_and_apply_fitted_levels(
             bad_levels[key] = scale
         else:
             # scale full bank data by offset
-            s_q_norm.setY(ws_index, s_q_norm.dataY(ws_index) * (1.0 / (1.0 - offset)))
+            factor_tmp = 1.0 / (1.0 - offset)
+            s_q_norm.setY(ws_index, s_q_norm.dataY(ws_index) * factor_tmp)
 
         DeleteWorkspace("__tmp_bank_fit")
 

--- a/total_scattering/reduction/normalizations.py
+++ b/total_scattering/reduction/normalizations.py
@@ -26,11 +26,11 @@ class Material:
 
     @property
     def bcoh_avg_sqrd(self):
-        return self.cohScatterLength()**2
+        return self.cohScatterLength()**2 / 100.
 
     @property
     def btot_sqrd_avg(self):
-        return self.totalScatterLengthSqrd()
+        return self.totalScatterLengthSqrd() / 100.
 
     @property
     def laue_monotonic_diffuse_scat(self):
@@ -115,12 +115,14 @@ def calculate_and_apply_fitted_levels(
                                     CalculateOffset=True,
                                     CalculateScale=False)
         offset = match_result.Offset[1]
-        # if offset is <= 0, then we want to skip applying the scale
-        if offset < 0.0 or np.isclose(offset, 0.0):
-            bad_levels[key] = offset
+        scale = match_result.Scale[1]
+        # Scale away from 1.0 means the baseline is tilting and therefore we
+        # may have some uncorrected effect (e.g., hydrogen background).
+        if abs(scale - 1.0) > 0.5:
+            bad_levels[key] = scale
         else:
             # scale full bank data by offset
-            s_q_norm.setY(ws_index, s_q_norm.dataY(ws_index) * (1.0 / offset))
+            s_q_norm.setY(ws_index, s_q_norm.dataY(ws_index) * (1.0 / (1.0 - offset)))
 
         DeleteWorkspace("__tmp_bank_fit")
 

--- a/total_scattering/reduction/total_scattering_reduction.py
+++ b/total_scattering/reduction/total_scattering_reduction.py
@@ -1438,7 +1438,8 @@ def TotalScatteringReduction(config=None):
         if bad_fitted_levels:
             for bank, scale in bad_fitted_levels.items():
                 final_message +=\
-                    f'Bank {bank} potentially has a tilted baseline with the fitted scale = {scale} ' \
+                    f'Bank {bank} potentially has a tilted baseline with ' \
+                    f'the fitted scale = {scale} ' \
                     f'and was not scaled in {sam_corrected_norm_scaled}\n'
         save_banks(
             InputWorkspace=sam_corrected_norm_scaled,

--- a/total_scattering/reduction/total_scattering_reduction.py
+++ b/total_scattering/reduction/total_scattering_reduction.py
@@ -1436,9 +1436,9 @@ def TotalScatteringReduction(config=None):
                                               self_scattering_level_correction,
                                               sam_corrected_norm_scaled)
         if bad_fitted_levels:
-            for bank, offset in bad_fitted_levels.items():
+            for bank, scale in bad_fitted_levels.items():
                 final_message +=\
-                    f'Bank {bank} had a bad fitted level of {offset} ' \
+                    f'Bank {bank} potentially has a tilted baseline with the fitted scale = {scale} ' \
                     f'and was not scaled in {sam_corrected_norm_scaled}\n'
         save_banks(
             InputWorkspace=sam_corrected_norm_scaled,


### PR DESCRIPTION
1. The original calculation for scattering length and therefore the normalization coefficients was wrong since `fm^2` unit was used for cross section but rather it should be `barn`.

2. The condition for improperly determined final scale is changed so that it will give warning (and therefore not going to correct the self-scattering level) when the fitted scale is not close to 1.