### PR TITLE
Enable multiple scattering correction for standard Mantid total scattering workflow

### DIFF
--- a/tests/total_scattering/test_validator.py
+++ b/tests/total_scattering/test_validator.py
@@ -2,21 +2,22 @@
 import unittest
 from total_scattering.reduction.validator import validateConfig
 
+
 class CliTest(unittest.TestCase):
     demoConfig = {
         "Facility": "SNS",
         "Instrument": "NOM",
-        "Title" : "ceriaDP375_PAC06_at_300K_IDL_Calib",
-        "Calibration":{"Filename":"/SNS/users/y8z/Data/Igor_Ceria_New/shared/NOM_calibrate_d143068_2020_02_11.h5"},
-        "AlignAndFocusArgs" : { "TMin" : 300.0, "TMax" : 16667.0 },
-        "HighQLinearFitRange" : 0.60,
-        "Merging":{"QBinning": [0.0, 0.005, 40.0],
-                    "SumBanks": [3]
-                    },
+        "Title": "ceriaDP375_PAC06_at_300K_IDL_Calib",
+        "Calibration": {
+            "Filename": "/SNS/users/y8z/Data/Igor_Ceria_New/shared/NOM_calibrate_d143068_2020_02_11.h5"
+        },
+        "AlignAndFocusArgs": {"TMin": 300.0, "TMax": 16667.0},
+        "HighQLinearFitRange": 0.60,
+        "Merging": {"QBinning": [0.0, 0.005, 40.0], "SumBanks": [3]},
         "Sample": {},
         "Normalization": {},
-        "CacheDir" : "./tmp",
-        "OutputDir" : "./output"
+        "CacheDir": "./tmp",
+        "OutputDir": "./output",
     }
 
     def test_validateConfig(self):
@@ -25,13 +26,13 @@ class CliTest(unittest.TestCase):
 
         # case 1: abs correction, but no ms correction for sample
         config = self.demoConfig.copy()
-        config["Sample"] = {"AbsorptionCorrection" : { "Type" : "SampleOnly" }}
+        config["Sample"] = {"AbsorptionCorrection": {"Type": "SampleOnly"}}
         validateConfig(config)
 
         # case 2: abs and ms correction for sample only
         config = self.demoConfig.copy()
         config["Sample"] = {
-            "AbsorptionCorrection" : { "Type" : "SampleOnly" },
+            "AbsorptionCorrection": {"Type": "SampleOnly"},
             "MultipleScatteringCorrection": {"Type": "SampleOnly"},
         }
         validateConfig(config)
@@ -39,13 +40,14 @@ class CliTest(unittest.TestCase):
         # case 3: abs and ms correction for sample and container
         config = self.demoConfig.copy()
         config["Sample"] = {
-            "AbsorptionCorrection" : { "Type" : "FullPaalmanPings" },
+            "AbsorptionCorrection": {"Type": "FullPaalmanPings"},
             "MultipleScatteringCorrection": {"Type": "SampleAndContainer"},
         }
         config["Normalization"] = {
-            "AbsorptionCorrection" : { "Type" : "SampleOnly" },
+            "AbsorptionCorrection": {"Type": "SampleOnly"},
             "MultipleScatteringCorrection": {"Type": "SampleOnly"},
         }
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/total_scattering/test_validator.py
+++ b/tests/total_scattering/test_validator.py
@@ -1,0 +1,51 @@
+# standard imports
+import unittest
+from total_scattering.reduction.validator import validateConfig
+
+class CliTest(unittest.TestCase):
+    demoConfig = {
+        "Facility": "SNS",
+        "Instrument": "NOM",
+        "Title" : "ceriaDP375_PAC06_at_300K_IDL_Calib",
+        "Calibration":{"Filename":"/SNS/users/y8z/Data/Igor_Ceria_New/shared/NOM_calibrate_d143068_2020_02_11.h5"},
+        "AlignAndFocusArgs" : { "TMin" : 300.0, "TMax" : 16667.0 },
+        "HighQLinearFitRange" : 0.60,
+        "Merging":{"QBinning": [0.0, 0.005, 40.0],
+                    "SumBanks": [3]
+                    },
+        "Sample": {},
+        "Normalization": {},
+        "CacheDir" : "./tmp",
+        "OutputDir" : "./output"
+    }
+
+    def test_validateConfig(self):
+        # case 0: no abs nor ms correction
+        validateConfig(self.demoConfig)
+
+        # case 1: abs correction, but no ms correction for sample
+        config = self.demoConfig.copy()
+        config["Sample"] = {"AbsorptionCorrection" : { "Type" : "SampleOnly" }}
+        validateConfig(config)
+
+        # case 2: abs and ms correction for sample only
+        config = self.demoConfig.copy()
+        config["Sample"] = {
+            "AbsorptionCorrection" : { "Type" : "SampleOnly" },
+            "MultipleScatteringCorrection": {"Type": "SampleOnly"},
+        }
+        validateConfig(config)
+
+        # case 3: abs and ms correction for sample and container
+        config = self.demoConfig.copy()
+        config["Sample"] = {
+            "AbsorptionCorrection" : { "Type" : "FullPaalmanPings" },
+            "MultipleScatteringCorrection": {"Type": "SampleAndContainer"},
+        }
+        config["Normalization"] = {
+            "AbsorptionCorrection" : { "Type" : "SampleOnly" },
+            "MultipleScatteringCorrection": {"Type": "SampleOnly"},
+        }
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/total_scattering/test_validator.py
+++ b/tests/total_scattering/test_validator.py
@@ -9,7 +9,7 @@ class CliTest(unittest.TestCase):
         "Instrument": "NOM",
         "Title": "ceriaDP375_PAC06_at_300K_IDL_Calib",
         "Calibration": {
-            "Filename": "/SNS/users/y8z/Data/Igor_Ceria_New/shared/NOM_calibrate_d143068_2020_02_11.h5"
+            "Filename": "test.h5"  # don't need a real file here
         },
         "AlignAndFocusArgs": {"TMin": 300.0, "TMax": 16667.0},
         "HighQLinearFitRange": 0.60,

--- a/total_scattering/cli.py
+++ b/total_scattering/cli.py
@@ -1,22 +1,25 @@
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
 
 import json
 from total_scattering.reduction import TotalScatteringReduction
 from total_scattering.reduction import validateConfig
+
 
 def main(config=None):
 
     # Read in JSON if not provided to main()
     if not config:
         import argparse
+
         parser = argparse.ArgumentParser(
-            description="Absolute normalization PDF generation")
-        parser.add_argument('json', help='Input json file')
+            description="Absolute normalization PDF generation"
+        )
+        parser.add_argument("json", help="Input json file")
         options = parser.parse_args()
         print("loading config from '%s'" % options.json)
-        with open(options.json, 'r') as handle:
+        with open(options.json, "r") as handle:
             config = json.load(handle)
-    
+
     # validate the config
     validateConfig(config)
 

--- a/total_scattering/cli.py
+++ b/total_scattering/cli.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import json
 from total_scattering.reduction import TotalScatteringReduction
-
+from total_scattering.reduction import validateConfig
 
 def main(config=None):
 
@@ -16,6 +16,9 @@ def main(config=None):
         print("loading config from '%s'" % options.json)
         with open(options.json, 'r') as handle:
             config = json.load(handle)
+    
+    # validate the config
+    validateConfig(config)
 
     # Run total scattering reduction
     TotalScatteringReduction(config)

--- a/total_scattering/file_handling/load.py
+++ b/total_scattering/file_handling/load.py
@@ -96,12 +96,6 @@ def create_absorption_wksp(filename, abs_method, geometry, material,
     if abs_method is None:
         return '', ''
 
-    # Check against supported absorption corrections, error out early if needed
-    valid_methods = ["SampleOnly", "SampleAndContainer", "FullPaalmanPings"]
-    if abs_method not in valid_methods:
-        msg = "Unrecognized absorption correction method '{}'"
-        raise RuntimeError(msg.format(abs_method))
-
     abs_input = Load(filename, MetaDataOnly=True)
 
     # If no run characterization properties given, load any provided files

--- a/total_scattering/file_handling/load.py
+++ b/total_scattering/file_handling/load.py
@@ -96,6 +96,7 @@ def create_absorption_wksp(filename, abs_method, geometry, material,
                            environment=None, props=None,
                            characterization_files=None,
                            ms_method=None,
+                           elementsize=1.0, # mm
                            **align_and_focus_args):
     '''Create absorption workspace'''
     if abs_method is None:
@@ -204,20 +205,18 @@ def create_absorption_wksp(filename, abs_method, geometry, material,
     #    calling to cache
     abs_s, abs_c = absorptioncorrutils.calc_absorption_corr_using_wksp(
             donor_ws,
-            abs_method)
+            abs_method,
+            element_size=elementsize)
 
     # 3. Convert to effective absorption correction workspace if multiple
     # scattering correction is requested
     # NOTE:
-    #   There is no entry for specifying the element size yet, and we are
-    #   unclear if heterogeneous element size will be implemented in the
-    #   future, therefore we will be using the default 1mm element size
-    #   for multiple scattering correction, regardless of the container
-    #   thickness (which might lead to incorrect results).
+    #   Multiple scattering and absorption correction are using the same
+    #   element size when discretizing the volume.
     if ms_method is not None:
         MultipleScatteringCorrection(
             InputWorkspace=donor_ws,
-            ElementSize=1.0,  # Default element size 1 mm
+            ElementSize=elementsize,
             method=ms_method,
             OutputWorkspace="ms_tmp"
         )

--- a/total_scattering/file_handling/load.py
+++ b/total_scattering/file_handling/load.py
@@ -179,7 +179,7 @@ def create_absorption_wksp(filename, abs_method, geometry, material,
     abs_s, abs_c = absorptioncorrutils.calc_absorption_corr_using_wksp(
             donor_ws,
             abs_method)
-    
+
     # Convert to effective absorption correction workspace if multiple
     # scattering correction is requested
     # NOTE:
@@ -192,7 +192,7 @@ def create_absorption_wksp(filename, abs_method, geometry, material,
         ms_input = Load(filename, MetaDataOnly=True)
         MultipleScatteringCorrection(
             InputWorkspace=ms_input,
-            ElementSize=1.0, # Default element size 1 mm
+            ElementSize=1.0,  # Default element size 1 mm
             method=ms_method,
             OutputWorkspace="ms_tmp"
         )
@@ -202,9 +202,9 @@ def create_absorption_wksp(filename, abs_method, geometry, material,
             # abs_s now point to the effective absorption correction
             # A = A / (1 - ms_s)
             Divide(
-                LHSWorkspace=abs_s, # str
-                RHSWorkspace=ms_sampleOnly, # workspace
-                OutputWorkspace=abs_s, # str
+                LHSWorkspace=abs_s,  # str
+                RHSWorkspace=ms_sampleOnly,  # workspace
+                OutputWorkspace=abs_s,  # str
                 )
             # nothing need to be done for container
             mtd.remove("ms_tmp_sampleOnly")
@@ -212,17 +212,17 @@ def create_absorption_wksp(filename, abs_method, geometry, material,
             ms_sampleAndContainer = mtd["ms_tmp_sampleAndContainer"]
             ms_sampleAndContainer = 1 - ms_sampleAndContainer
             Divide(
-                LHSWorkspace=abs_s, # str
-                RHSWorkspace=ms_sampleAndContainer, # workspace
-                OutputWorkspace=abs_s, # str
+                LHSWorkspace=abs_s,  # str
+                RHSWorkspace=ms_sampleAndContainer,  # workspace
+                OutputWorkspace=abs_s,  # str
             )
             mtd.remove("ms_tmp_sampleAndContainer")
             ms_containerOnly = mtd["ms_tmp_containerOnly"]
             ms_containerOnly = 1 - ms_containerOnly
             Divide(
-                LHSWorkspace=abs_c, # str
-                RHSWorkspace=ms_containerOnly, # workspace
-                OutputWorkspace=abs_c, # str
+                LHSWorkspace=abs_c,  # str
+                RHSWorkspace=ms_containerOnly,  # workspace
+                OutputWorkspace=abs_c,  # str
             )
             mtd.remove("ms_tmp_containerOnly")
         else:

--- a/total_scattering/file_handling/load.py
+++ b/total_scattering/file_handling/load.py
@@ -116,11 +116,15 @@ def create_absorption_wksp(filename, abs_method, geometry, material,
         chars = charTable[0]
 
         # Create the properties for the absorption workspace
-        #  Note: Should BackRun, NormRun, and NormBackRun be specified here?
+        # NOTE
+        # WaveLengthLogNames used here will be the standard default one in the
+        # future, however let's keep them in until Mantid_v6.3 comes out
         PDDetermineCharacterizations(
             InputWorkspace=abs_input,
             Characterizations=chars,
             ReductionProperties="__absreductionprops",
+            WaveLengthLogNames="LambdaRequest,lambda,skf12.lambda,"
+                               "BL1B:Det:TH:BL:Lambda,freq"
             )
         props = PropertyManagerDataService.retrieve("__absreductionprops")
 
@@ -129,9 +133,14 @@ def create_absorption_wksp(filename, abs_method, geometry, material,
         msg = ("No props or characterizations were given, "
                "determining props from input file")
         print(msg)
+        # NOTE
+        # WaveLengthLogNames used here will be the standard default one in the
+        # future, however let's keep them in until Mantid_v6.3 comes out
         PDDetermineCharacterizations(
             InputWorkspace=abs_input,
             ReductionProperties="__absreductionprops",
+            WaveLengthLogNames="LambdaRequest,lambda,skf12.lambda,"
+                               "BL1B:Det:TH:BL:Lambda,freq"
             )
         props = PropertyManagerDataService.retrieve("__absreductionprops")
 

--- a/total_scattering/file_handling/load.py
+++ b/total_scattering/file_handling/load.py
@@ -121,8 +121,7 @@ def create_absorption_wksp(filename, abs_method, geometry, material,
             InputWorkspace=abs_input,
             Characterizations=chars,
             ReductionProperties="__absreductionprops",
-            WaveLengthLogNames="LambdaRequest,lambda,skf12.lambda,"
-                               "BL1B:Det:TH:BL:Lambda,freq")
+            )
         props = PropertyManagerDataService.retrieve("__absreductionprops")
 
     # If neither run characterization properties or files, guess from input
@@ -133,8 +132,7 @@ def create_absorption_wksp(filename, abs_method, geometry, material,
         PDDetermineCharacterizations(
             InputWorkspace=abs_input,
             ReductionProperties="__absreductionprops",
-            WaveLengthLogNames="LambdaRequest,lambda,skf12.lambda,"
-                               "BL1B:Det:TH:BL:Lambda,freq")
+            )
         props = PropertyManagerDataService.retrieve("__absreductionprops")
 
         # Default to wavelength from JSON input / align and focus args
@@ -189,9 +187,8 @@ def create_absorption_wksp(filename, abs_method, geometry, material,
     #   for multiple scattering correction, regardless of the container
     #   thickness (which might lead to incorrect results).
     if ms_method is not None:
-        ms_input = Load(filename, MetaDataOnly=True)
         MultipleScatteringCorrection(
-            InputWorkspace=ms_input,
+            InputWorkspace=donor_ws,
             ElementSize=1.0,  # Default element size 1 mm
             method=ms_method,
             OutputWorkspace="ms_tmp"

--- a/total_scattering/file_handling/load.py
+++ b/total_scattering/file_handling/load.py
@@ -157,7 +157,24 @@ def create_absorption_wksp(filename, abs_method, geometry, material,
                 if logname_wl in run and is_max_wavelength_zero:
                     props["wavelength_max"] = run[logname_wl].lastValue()
 
-    # Setup the donor workspace for absorption correction
+    # NOTE: We have two options from this point forward.
+    #       As of 10-04-2021, use option 2 to bypass the automated caching
+
+    # Option 1: use top level API from absorptioncorrutils for easy caching
+    # abs_s, abs_c = absorptioncorrutils.calculate_absorption_correction(
+    #                   filename,
+    #                   abs_method,
+    #                   props,
+    #                   sample_formula=material['ChemicalFormula'],
+    #                   mass_density=material['SampleMassDensity'],
+    #                   cache_dir=align_and_focus_args["CacheDir"],
+    #                   ms_method=ms_method,
+    # )
+
+    # Option 2 (Original method)
+    # Use low level API from absorptioncorrutils to bypass the automated
+    # caching
+    # 1. Setup the donor workspace for absorption correction
     try:
         if isinstance(filename, str):
             list_filenames = filename.split(",")
@@ -174,11 +191,13 @@ def create_absorption_wksp(filename, abs_method, geometry, material,
         msg = "Could not create absorption correction donor workspace: {}"
         raise RuntimeError(msg.format(e))
 
+    # 2. calculate the absorption workspace (first order absorption) without
+    #    calling to cache
     abs_s, abs_c = absorptioncorrutils.calc_absorption_corr_using_wksp(
             donor_ws,
             abs_method)
 
-    # Convert to effective absorption correction workspace if multiple
+    # 3. Convert to effective absorption correction workspace if multiple
     # scattering correction is requested
     # NOTE:
     #   There is no entry for specifying the element size yet, and we are

--- a/total_scattering/reduction/__init__.py
+++ b/total_scattering/reduction/__init__.py
@@ -1,2 +1,2 @@
 from total_scattering.reduction.total_scattering_reduction import TotalScatteringReduction  # noqa
-from total_scattering.reduction.validator import validateConfig
+from total_scattering.reduction.validator import validateConfig # noqa

--- a/total_scattering/reduction/__init__.py
+++ b/total_scattering/reduction/__init__.py
@@ -1,1 +1,2 @@
 from total_scattering.reduction.total_scattering_reduction import TotalScatteringReduction  # noqa
+from total_scattering.reduction.validator import validateConfig

--- a/total_scattering/reduction/total_scattering_reduction.py
+++ b/total_scattering/reduction/total_scattering_reduction.py
@@ -780,13 +780,35 @@ def TotalScatteringReduction(config: dict = None):
     print("Vanadium natoms:", nvan_atoms)
     print("Vanadium natoms / Sample natoms:", nvan_atoms / natoms)
 
-    # Load Vanadium Background
+    # ------------------------ #
+    # Load Vanadium Background #
+    # ------------------------ #
+    # NOTE:
+    # The full formula is
+    #      alpha_s(I_s - I_e) - alpha_c(I_c - I_e)
+    # I = ----------------------------------------
+    #          alpha_v (I_v - I_v,e)
+    #
+    #      alpha_s I_s - alpha_c I_c - alpha_e I_e
+    #   = -----------------------------------------
+    #          alpha_v I_v - alpha_v I_v,e
+    #
+    # where
+    #   * I_v,e is vanadium background
+    #   * alpha_e = (alpha_s - alpha_c)
+    #
+    # ALSO, alpha is the inverse of [effective] absorption coefficient, i.e.
+    #                alpha = 1/A
     van_bg = None
     if van_bg_scans is not None:
         print("#-----------------------------------#")
         print("# Vanadium Background")
         print("#-----------------------------------#")
-        van_bg = load('vanadium_background', van_bg_scans, **alignAndFocusArgs)
+        # van_bg = alpha_v I_v,e
+        van_bg = load(
+            'vanadium_background', van_bg_scans, # position args
+            absorption_wksp=van_abs_corr_ws,
+            **alignAndFocusArgs)
         vanadium_bg_title = "vanadium_background"
         save_banks(
             InputWorkspace=van_bg,

--- a/total_scattering/reduction/total_scattering_reduction.py
+++ b/total_scattering/reduction/total_scattering_reduction.py
@@ -575,6 +575,11 @@ def TotalScatteringReduction(config: dict = None):
     sam_ms_corr = sample.get("MultipleScatteringCorrection", None)
     sam_inelastic_corr = SetInelasticCorrection(
         sample.get('InelasticCorrection', None))
+    # get the element size
+    sam_abs_ms_param = sample.get("AbsMSParameters", None)
+    sam_elementsize = 1.0  # mm
+    if sam_abs_ms_param:
+        sam_elementsize = sam_abs_ms_param.get("ElementSize", 1.0)
 
     # Warn about having absorption correction and multiple scat correction set
     if sam_abs_corr and sam_ms_corr:
@@ -601,6 +606,7 @@ def TotalScatteringReduction(config: dict = None):
             sam_mat_dict,
             sam_env_dict,
             ms_method=sam_ms_method,
+            elementsize=sam_elementsize,
             **config)
 
     # Get vanadium corrections
@@ -613,6 +619,11 @@ def TotalScatteringReduction(config: dict = None):
     van_ms_corr = van.get("MultipleScatteringCorrection", {"Type": None})
     van_inelastic_corr = SetInelasticCorrection(
         van.get('InelasticCorrection', None))
+    # get the elementsize for vanadium
+    van_abs_ms_param = van.get("AbsMSParameters", None)
+    van_elementsize = 1.0
+    if van_abs_ms_param:
+        van_elementsize = van_abs_ms_param.get("ElementSize", 1.0)
 
     # Warn about having absorption correction and multiple scat correction set
     if van_abs_corr["Type"] and van_ms_corr["Type"]:
@@ -637,6 +648,7 @@ def TotalScatteringReduction(config: dict = None):
             van_geo_dict,
             van_mat_dict,
             ms_method=van_ms_method,
+            elementsize=van_elementsize,
             **config)
 
     #################################################################

--- a/total_scattering/reduction/total_scattering_reduction.py
+++ b/total_scattering/reduction/total_scattering_reduction.py
@@ -586,12 +586,21 @@ def TotalScatteringReduction(config: dict = None):
     if sam_abs_corr:
         msg = "Applying '{}' absorption correction to sample"
         log.notice(msg.format(sam_abs_corr["Type"]))
+        sam_ms_method = None
+        if sam_ms_corr:
+            sam_ms_method = sam_ms_corr.get("Type", None)
+            if sam_ms_method is not None:
+                log.notice(
+                    f"Apply {sam_ms_method} multiple scattering correction"
+                    "to sample"
+                )
         sam_abs_ws, con_abs_ws = create_absorption_wksp(
             sam_scans,
             sam_abs_corr["Type"],
             sam_geo_dict,
             sam_mat_dict,
             sam_env_dict,
+            ms_method=sam_ms_method,
             **config)
 
     # Get vanadium corrections
@@ -614,11 +623,20 @@ def TotalScatteringReduction(config: dict = None):
     if van_abs_corr:
         msg = "Applying '{}' absorption correction to vanadium"
         log.notice(msg.format(van_abs_corr["Type"]))
+        van_ms_method = None
+        if van_ms_corr:
+            van_ms_method = van_ms_corr.get("Type", None)
+            if van_ms_method is not None:
+                log.notice(
+                    f"Apply {van_ms_method} multiple scattering correction"
+                    "to vanadium"
+                )
         van_abs_corr_ws, van_con_ws = create_absorption_wksp(
             van_scans,
             van_abs_corr["Type"],
             van_geo_dict,
             van_mat_dict,
+            ms_method=van_ms_method,
             **config)
 
     #################################################################

--- a/total_scattering/reduction/validator.py
+++ b/total_scattering/reduction/validator.py
@@ -1,5 +1,6 @@
 import logging
 
+
 def validateConfig(config: dict):
     """
     @description Validate the input config dict parsed from json
@@ -7,7 +8,7 @@ def validateConfig(config: dict):
     @param config: dict
         config dict parsed from json
     """
-    #NOTE:
+    # NOTE:
     #   All config validation should be performed prior to calling the reduction
     #   function, following the "fail early" principle.
 
@@ -25,53 +26,94 @@ def validateConfig(config: dict):
     # FullPaalmanPings   |    OK       ERR            OK             ERR       ERR
     # Mayers             |    OK       OK             ERR            OK        ERR
     # Carpenter          |    WARN     WARN           ERR            ERR       WARN
-    valid_absorption_methods =  ["None", "SampleOnly", "SampleAndContainer", "FullPaalmanPings", "Mayers", "Carpenter"]
-    valid_multiple_scattering_methods = ["None", "SampleOnly", "SampleAndContainer", "Mayers", "Carpenter"]
+    valid_absorption_methods = [
+        "None",
+        "SampleOnly",
+        "SampleAndContainer",
+        "FullPaalmanPings",
+        "Mayers",
+        "Carpenter",
+    ]
+    valid_multiple_scattering_methods = [
+        "None",
+        "SampleOnly",
+        "SampleAndContainer",
+        "Mayers",
+        "Carpenter",
+    ]
     sam_abs = config["Sample"].get("AbsorptionCorrection", None)
     sam_ms = config["Sample"].get("MultipleScatteringCorrection", None)
     if sam_abs is None:
         # missing AbsorptionCorrection section, which means no abs or ms correction
         if sam_ms is None:
-            logging.warning("No AbsorptionCorrection or MultipleScatteringCorrection found for Sample, will skip both.")
+            logging.warning(
+                "No AbsorptionCorrection or MultipleScatteringCorrection found for Sample, will skip both."
+            )
         else:
-            raise ValueError("AbsorptionCorrection section is missing but MultipleScatteringCorrection section is present")
+            raise ValueError(
+                "AbsorptionCorrection section is missing but MultipleScatteringCorrection section is present"
+            )
     else:
         sam_abs_type = sam_abs.get("Type", None)
         # quick check to make sure a known absorption correction method is used
         if str(sam_abs_type) not in valid_absorption_methods:
-            raise ValueError("AbsorptionCorrection.Type is invalid: {}".format(sam_abs_type))
+            raise ValueError(
+                "AbsorptionCorrection.Type is invalid: {}".format(sam_abs_type)
+            )
         # going through the logic map (see above)
         if sam_ms is None:
-            logging.info("The reduction will skip multiple scattering correction for sample.")
+            logging.info(
+                "The reduction will skip multiple scattering correction for sample."
+            )
         else:
             sam_ms_type = sam_ms.get("Type", None)
             # quick check to make sure a known multiple scattering correction method is used
             if str(sam_ms_type) not in valid_multiple_scattering_methods:
-                raise ValueError("MultipleScatteringCorrection.Type is invalid: {}".format(sam_ms_type))
+                raise ValueError(
+                    "MultipleScatteringCorrection.Type is invalid: {}".format(
+                        sam_ms_type
+                    )
+                )
             #
             if sam_abs_type is None:
                 if sam_ms_type is not None:
-                    raise ValueError("Any multiple scattering correction requires corresponding absorption correction")
+                    raise ValueError(
+                        "Any multiple scattering correction requires corresponding absorption correction"
+                    )
             elif sam_abs_type == "SampleOnly":
                 if sam_ms_type == "SampleAndContainer":
-                    raise ValueError("SampleAndContainer multiple scattering correction conflicts with SampleOnly absorption correction.")
+                    raise ValueError(
+                        f"ms_{sam_ms_type} is incompatible with abs_{sam_abs_type}."
+                    )
                 elif sam_ms_type == "Carpenter":
-                    logging.warning("Carpenter multiple scattering correction is only valid for Vanadium.")
+                    logging.warning(
+                        "Carpenter multiple scattering correction is only valid for Vanadium."
+                    )
                 else:
                     pass
             elif sam_abs_type in ["SampleAndContainer", "FullPaalmanPings"]:
                 if str(sam_ms_type) not in ["None", "SampleAndContainer"]:
-                    raise ValueError(f"{sam_ms_type} is incompatible with {sam_abs_type}.")
+                    raise ValueError(
+                        f"ms_{sam_ms_type} is incompatible with abs_{sam_abs_type}."
+                    )
             elif sam_abs_type == "Mayers":
                 if sam_ms_type in ["SampleAndContainer", "Carpenter"]:
-                    raise ValueError(f"{sam_ms_type} is incompatible with {sam_abs_type}.")
+                    raise ValueError(
+                        f"ms_{sam_ms_type} is incompatible with abs_{sam_abs_type}."
+                    )
             elif sam_abs_type == "Carpenter":
                 if sam_ms_type in ["SampleAndContainer", "Mayers"]:
-                    raise ValueError(f"{sam_ms_type} is incompatible with {sam_abs_type}.")
+                    raise ValueError(
+                        f"ms_{sam_ms_type} is incompatible with abs_{sam_abs_type}."
+                    )
                 else:
-                    logging.warning("Carpenter multiple scattering correction is only valid for Vanadium.")
+                    logging.warning(
+                        "Carpenter multiple scattering correction is only valid for Vanadium."
+                    )
             else:
-                logging.info(f"[Sample] will use {sam_abs_type} for absorption and {sam_ms_type} for multiple scattering")
+                logging.info(
+                    f"[Sample] will use {sam_abs_type} for absorption, {sam_ms_type} for multiple scattering"
+                )
 
     # ------------------------ #
     # Vanadium (normalization) #
@@ -87,40 +129,62 @@ def validateConfig(config: dict):
     # Carpenter          |    OK       OK         ERR       OK
     va_abs = config["Normalization"].get("AbsorptionCorrection", None)
     va_ms = config["Normalization"].get("MultipleScatteringCorrection", None)
-    valid_absorption_methods =  ["None", "SampleOnly", "Mayers", "Carpenter"]
+    valid_absorption_methods = ["None", "SampleOnly", "Mayers", "Carpenter"]
     valid_multiple_scattering_methods = ["None", "SampleOnly", "Mayers", "Carpenter"]
     if va_abs is None:
         # missing AbsorptionCorrection section, which means no abs or ms correction
         if va_ms is None:
-            logging.warning("No AbsorptionCorrection or MultipleScatteringCorrection found for Normalization, will skip both.")
+            logging.warning(
+                "Skip both absorption and multiple scattering correction."
+            )
         else:
-            raise ValueError("AbsorptionCorrection section is missing but MultipleScatteringCorrection section is present in Normalization")
+            raise ValueError(
+                "Missing absorptionCorrection but found MultipleScatteringCorrection in Normalization"
+            )
     else:
         va_abs_type = va_abs.get("Type", None)
         if str(va_abs_type) not in valid_absorption_methods:
-            raise ValueError("AbsorptionCorrection.Type is invalid: {}".format(va_abs_type))
+            raise ValueError(
+                "AbsorptionCorrection.Type is invalid: {}".format(va_abs_type)
+            )
         #
         if va_ms is None:
-            logging.info("The reduction will skip multiple scattering correction for normalization.")
+            logging.info(
+                "Will skip multiple scattering correction for normalization."
+            )
         else:
             va_ms_type = va_ms.get("Type", None)
             if str(va_ms_type) not in valid_multiple_scattering_methods:
-                raise ValueError("MultipleScatteringCorrection.Type is invalid: {}".format(va_ms_type))
+                raise ValueError(
+                    "MultipleScatteringCorrection.Type is invalid: {}".format(
+                        va_ms_type
+                    )
+                )
             #
             if va_abs_type is None:
                 if va_ms_type is None:
-                    logging.warning("skipping absorption and multiple scattering correction for normalization.")
+                    logging.warning(
+                        "skipping absorption and multiple scattering for normalization."
+                    )
                 else:
-                    raise ValueError("multiple scattering correction requires absorption correction.")
+                    raise ValueError(
+                        "multiple scattering correction requires absorption correction."
+                    )
             elif va_abs_type == "Mayers":
                 if va_ms_type == "Carpenter":
-                    raise ValueError("Carpenter multiple scattering correction is incompatible with Mayers absorption correction.")
+                    raise ValueError(
+                        "Carpenter multiple scattering correction is incompatible with Mayers absorption correction."
+                    )
                 else:
                     pass
             elif va_abs_type == "Carpenter":
                 if va_ms_type == "Mayers":
-                    raise ValueError("Mayers multiple scattering correction is incompatible with Carpenter absorption correction.")
+                    raise ValueError(
+                        "Mayers multiple scattering correction is incompatible with Carpenter absorption correction."
+                    )
                 else:
                     pass
             else:
-                logging.info(f"[Normalization] will use {va_abs_type} for absorption and {va_ms_type} for multiple scattering")
+                logging.info(
+                    f"[Normalization] will use {va_abs_type} for absorption and {va_ms_type} for multiple scattering"
+                )

--- a/total_scattering/reduction/validator.py
+++ b/total_scattering/reduction/validator.py
@@ -9,8 +9,8 @@ def validateConfig(config: dict):
         config dict parsed from json
     """
     # NOTE:
-    #   All config validation should be performed prior to calling the reduction
-    #   function, following the "fail early" principle.
+    #   All config validation should be performed prior to calling the
+    #   reduction function, following the "fail early" principle.
 
     # ------ #
     # Sample #
@@ -18,14 +18,14 @@ def validateConfig(config: dict):
     # --> multiple scattering correction
     # |
     # v Absorption correction
-    #                    |   None	SampleOnly	SampleAndContainer	Mayers	Carpenter
-    # ----------------------------------------------------------------------------------
-    # None               |    OK       ERR            ERR            ERR       ERR
-    # SampleOnly         |    OK       OK             ERR            OK        WARN
-    # SampleAndContainer |    OK       ERR            OK             ERR       ERR
-    # FullPaalmanPings   |    OK       ERR            OK             ERR       ERR
-    # Mayers             |    OK       OK             ERR            OK        ERR
-    # Carpenter          |    WARN     WARN           ERR            ERR       WARN
+    #                   None  SampleOnly SampleAndContainer Mayers Carpenter
+    # --------------------------------------------------------------------------
+    # None               OK     ERR          ERR            ERR       ERR
+    # SampleOnly         OK     OK           ERR            OK        WARN
+    # SampleAndContainer OK     ERR          OK             ERR       ERR
+    # FullPaalmanPings   OK     ERR          OK             ERR       ERR
+    # Mayers             OK     OK           ERR            OK        ERR
+    # Carpenter          WARN   WARN         ERR            ERR       WARN
     valid_absorption_methods = [
         "None",
         "SampleOnly",
@@ -44,14 +44,16 @@ def validateConfig(config: dict):
     sam_abs = config["Sample"].get("AbsorptionCorrection", None)
     sam_ms = config["Sample"].get("MultipleScatteringCorrection", None)
     if sam_abs is None:
-        # missing AbsorptionCorrection section, which means no abs or ms correction
+        # missing AbsorptionCorrection section, which means no abs or ms
+        # correction
         if sam_ms is None:
             logging.warning(
-                "No AbsorptionCorrection or MultipleScatteringCorrection found for Sample, will skip both."
+                "No AbsorptionCorrection or MultipleScatteringCorrection found."
             )
         else:
             raise ValueError(
-                "AbsorptionCorrection section is missing but MultipleScatteringCorrection section is present"
+                "AbsorptionCorrection section is missing but"
+                "MultipleScatteringCorrection section is present"
             )
     else:
         sam_abs_type = sam_abs.get("Type", None)
@@ -63,11 +65,13 @@ def validateConfig(config: dict):
         # going through the logic map (see above)
         if sam_ms is None:
             logging.info(
-                "The reduction will skip multiple scattering correction for sample."
+                "The reduction will skip multiple scattering correction"
+                "for sample."
             )
         else:
             sam_ms_type = sam_ms.get("Type", None)
-            # quick check to make sure a known multiple scattering correction method is used
+            # quick check to make sure a known multiple scattering correction
+            # method is used
             if str(sam_ms_type) not in valid_multiple_scattering_methods:
                 raise ValueError(
                     "MultipleScatteringCorrection.Type is invalid: {}".format(
@@ -78,41 +82,49 @@ def validateConfig(config: dict):
             if sam_abs_type is None:
                 if sam_ms_type is not None:
                     raise ValueError(
-                        "Any multiple scattering correction requires corresponding absorption correction"
+                        "Any multiple scattering correction requires"
+                        "corresponding absorption correction"
                     )
             elif sam_abs_type == "SampleOnly":
                 if sam_ms_type == "SampleAndContainer":
                     raise ValueError(
-                        f"ms_{sam_ms_type} is incompatible with abs_{sam_abs_type}."
+                        f"ms_{sam_ms_type} is incompatible with"
+                        f"abs_{sam_abs_type}."
                     )
                 elif sam_ms_type == "Carpenter":
                     logging.warning(
-                        "Carpenter multiple scattering correction is only valid for Vanadium."
+                        "Carpenter multiple scattering correction is only"
+                        "valid for Vanadium."
                     )
                 else:
                     pass
             elif sam_abs_type in ["SampleAndContainer", "FullPaalmanPings"]:
                 if str(sam_ms_type) not in ["None", "SampleAndContainer"]:
                     raise ValueError(
-                        f"ms_{sam_ms_type} is incompatible with abs_{sam_abs_type}."
+                        f"ms_{sam_ms_type} is incompatible with"
+                        f"abs_{sam_abs_type}."
                     )
             elif sam_abs_type == "Mayers":
                 if sam_ms_type in ["SampleAndContainer", "Carpenter"]:
                     raise ValueError(
-                        f"ms_{sam_ms_type} is incompatible with abs_{sam_abs_type}."
+                        f"ms_{sam_ms_type} is incompatible with"
+                        f"abs_{sam_abs_type}."
                     )
             elif sam_abs_type == "Carpenter":
                 if sam_ms_type in ["SampleAndContainer", "Mayers"]:
                     raise ValueError(
-                        f"ms_{sam_ms_type} is incompatible with abs_{sam_abs_type}."
+                        f"ms_{sam_ms_type} is incompatible with"
+                        f"abs_{sam_abs_type}."
                     )
                 else:
                     logging.warning(
-                        "Carpenter multiple scattering correction is only valid for Vanadium."
+                        "Carpenter multiple scattering correction is"
+                        "only valid for Vanadium."
                     )
             else:
                 logging.info(
-                    f"[Sample] will use {sam_abs_type} for absorption, {sam_ms_type} for multiple scattering"
+                    f"[Sample] will use {sam_abs_type} for absorption,"
+                    f"{sam_ms_type} for multiple scattering"
                 )
 
     # ------------------------ #
@@ -130,16 +142,19 @@ def validateConfig(config: dict):
     va_abs = config["Normalization"].get("AbsorptionCorrection", None)
     va_ms = config["Normalization"].get("MultipleScatteringCorrection", None)
     valid_absorption_methods = ["None", "SampleOnly", "Mayers", "Carpenter"]
-    valid_multiple_scattering_methods = ["None", "SampleOnly", "Mayers", "Carpenter"]
+    valid_multiple_scattering_methods = [
+        "None", "SampleOnly", "Mayers", "Carpenter"]
     if va_abs is None:
-        # missing AbsorptionCorrection section, which means no abs or ms correction
+        # missing AbsorptionCorrection section, which means no abs
+        # or ms correction
         if va_ms is None:
             logging.warning(
                 "Skip both absorption and multiple scattering correction."
             )
         else:
             raise ValueError(
-                "Missing absorptionCorrection but found MultipleScatteringCorrection in Normalization"
+                "Missing absorptionCorrection but found"
+                "MultipleScatteringCorrection in Normalization"
             )
     else:
         va_abs_type = va_abs.get("Type", None)
@@ -164,27 +179,32 @@ def validateConfig(config: dict):
             if va_abs_type is None:
                 if va_ms_type is None:
                     logging.warning(
-                        "skipping absorption and multiple scattering for normalization."
+                        "skipping absorption and multiple scattering"
+                        "for normalization."
                     )
                 else:
                     raise ValueError(
-                        "multiple scattering correction requires absorption correction."
+                        "multiple scattering correction requires absorption"
+                        "correction."
                     )
             elif va_abs_type == "Mayers":
                 if va_ms_type == "Carpenter":
                     raise ValueError(
-                        "Carpenter multiple scattering correction is incompatible with Mayers absorption correction."
+                        "Carpenter multiple scattering correction is"
+                        "incompatible with Mayers absorption correction."
                     )
                 else:
                     pass
             elif va_abs_type == "Carpenter":
                 if va_ms_type == "Mayers":
                     raise ValueError(
-                        "Mayers multiple scattering correction is incompatible with Carpenter absorption correction."
+                        "Mayers multiple scattering correction is"
+                        "incompatible with Carpenter absorption correction."
                     )
                 else:
                     pass
             else:
                 logging.info(
-                    f"[Normalization] will use {va_abs_type} for absorption and {va_ms_type} for multiple scattering"
+                    f"[Normalization] will use {va_abs_type} for absorption"
+                    f"and {va_ms_type} for multiple scattering"
                 )

--- a/total_scattering/reduction/validator.py
+++ b/total_scattering/reduction/validator.py
@@ -24,8 +24,8 @@ def validateConfig(config: dict):
     # SampleOnly         OK     OK           ERR            OK        WARN
     # SampleAndContainer OK     ERR          OK             ERR       ERR
     # FullPaalmanPings   OK     ERR          OK             ERR       ERR
-    # Mayers             OK     OK           ERR            OK        ERR
-    # Carpenter          WARN   WARN         ERR            ERR       WARN
+    # Mayers             ERR    ERR          ERR            OK        ERR
+    # Carpenter          ERR    ERR          ERR            ERR       WARN
     valid_absorption_methods = [
         "None",
         "SampleOnly",
@@ -105,13 +105,13 @@ def validateConfig(config: dict):
                         f"abs_{sam_abs_type}."
                     )
             elif sam_abs_type == "Mayers":
-                if sam_ms_type in ["SampleAndContainer", "Carpenter"]:
+                if sam_ms_type != "Mayers":
                     raise ValueError(
                         f"ms_{sam_ms_type} is incompatible with"
                         f"abs_{sam_abs_type}."
                     )
             elif sam_abs_type == "Carpenter":
-                if sam_ms_type in ["SampleAndContainer", "Mayers"]:
+                if sam_ms_type != "Carpenter":
                     raise ValueError(
                         f"ms_{sam_ms_type} is incompatible with"
                         f"abs_{sam_abs_type}."

--- a/total_scattering/reduction/validator.py
+++ b/total_scattering/reduction/validator.py
@@ -1,0 +1,126 @@
+import logging
+
+def validateConfig(config: dict):
+    """
+    @description Validate the input config dict parsed from json
+
+    @param config: dict
+        config dict parsed from json
+    """
+    #NOTE:
+    #   All config validation should be performed prior to calling the reduction
+    #   function, following the "fail early" principle.
+
+    # ------ #
+    # Sample #
+    # ------ #
+    # --> multiple scattering correction
+    # |
+    # v Absorption correction
+    #                    |   None	SampleOnly	SampleAndContainer	Mayers	Carpenter
+    # ----------------------------------------------------------------------------------
+    # None               |    OK       ERR            ERR            ERR       ERR
+    # SampleOnly         |    OK       OK             ERR            OK        WARN
+    # SampleAndContainer |    OK       ERR            OK             ERR       ERR
+    # FullPaalmanPings   |    OK       ERR            OK             ERR       ERR
+    # Mayers             |    OK       OK             ERR            OK        ERR
+    # Carpenter          |    WARN     WARN           ERR            ERR       WARN
+    valid_absorption_methods =  ["None", "SampleOnly", "SampleAndContainer", "FullPaalmanPings", "Mayers", "Carpenter"]
+    valid_multiple_scattering_methods = ["None", "SampleOnly", "SampleAndContainer", "Mayers", "Carpenter"]
+    sam_abs = config["Sample"].get("AbsorptionCorrection", None)
+    sam_ms = config["Sample"].get("MultipleScatteringCorrection", None)
+    if sam_abs is None:
+        # missing AbsorptionCorrection section, which means no abs or ms correction
+        if sam_ms is None:
+            logging.warning("No AbsorptionCorrection or MultipleScatteringCorrection found for Sample, will skip both.")
+        else:
+            raise ValueError("AbsorptionCorrection section is missing but MultipleScatteringCorrection section is present")
+    else:
+        sam_abs_type = sam_abs.get("Type", None)
+        # quick check to make sure a known absorption correction method is used
+        if str(sam_abs_type) not in valid_absorption_methods:
+            raise ValueError("AbsorptionCorrection.Type is invalid: {}".format(sam_abs_type))
+        # going through the logic map (see above)
+        if sam_ms is None:
+            logging.info("The reduction will skip multiple scattering correction for sample.")
+        else:
+            sam_ms_type = sam_ms.get("Type", None)
+            # quick check to make sure a known multiple scattering correction method is used
+            if str(sam_ms_type) not in valid_multiple_scattering_methods:
+                raise ValueError("MultipleScatteringCorrection.Type is invalid: {}".format(sam_ms_type))
+            #
+            if sam_abs_type is None:
+                if sam_ms_type is not None:
+                    raise ValueError("Any multiple scattering correction requires corresponding absorption correction")
+            elif sam_abs_type == "SampleOnly":
+                if sam_ms_type == "SampleAndContainer":
+                    raise ValueError("SampleAndContainer multiple scattering correction conflicts with SampleOnly absorption correction.")
+                elif sam_ms_type == "Carpenter":
+                    logging.warning("Carpenter multiple scattering correction is only valid for Vanadium.")
+                else:
+                    pass
+            elif sam_abs_type in ["SampleAndContainer", "FullPaalmanPings"]:
+                if str(sam_ms_type) not in ["None", "SampleAndContainer"]:
+                    raise ValueError(f"{sam_ms_type} is incompatible with {sam_abs_type}.")
+            elif sam_abs_type == "Mayers":
+                if sam_ms_type in ["SampleAndContainer", "Carpenter"]:
+                    raise ValueError(f"{sam_ms_type} is incompatible with {sam_abs_type}.")
+            elif sam_abs_type == "Carpenter":
+                if sam_ms_type in ["SampleAndContainer", "Mayers"]:
+                    raise ValueError(f"{sam_ms_type} is incompatible with {sam_abs_type}.")
+                else:
+                    logging.warning("Carpenter multiple scattering correction is only valid for Vanadium.")
+            else:
+                logging.info(f"[Sample] will use {sam_abs_type} for absorption and {sam_ms_type} for multiple scattering")
+
+    # ------------------------ #
+    # Vanadium (normalization) #
+    # ------------------------ #
+    # --> multiple scattering correction
+    # |
+    # v Absorption correction
+    #                    |   None	SampleOnly	 Mayers	Carpenter
+    # ---------------------------------------------------------------
+    # None               |    OK       ERR        ERR       ERR
+    # SampleOnly         |    OK       OK         OK        OK
+    # Mayers             |    OK       OK         OK        ERR
+    # Carpenter          |    OK       OK         ERR       OK
+    va_abs = config["Normalization"].get("AbsorptionCorrection", None)
+    va_ms = config["Normalization"].get("MultipleScatteringCorrection", None)
+    valid_absorption_methods =  ["None", "SampleOnly", "Mayers", "Carpenter"]
+    valid_multiple_scattering_methods = ["None", "SampleOnly", "Mayers", "Carpenter"]
+    if va_abs is None:
+        # missing AbsorptionCorrection section, which means no abs or ms correction
+        if va_ms is None:
+            logging.warning("No AbsorptionCorrection or MultipleScatteringCorrection found for Normalization, will skip both.")
+        else:
+            raise ValueError("AbsorptionCorrection section is missing but MultipleScatteringCorrection section is present in Normalization")
+    else:
+        va_abs_type = va_abs.get("Type", None)
+        if str(va_abs_type) not in valid_absorption_methods:
+            raise ValueError("AbsorptionCorrection.Type is invalid: {}".format(va_abs_type))
+        #
+        if va_ms is None:
+            logging.info("The reduction will skip multiple scattering correction for normalization.")
+        else:
+            va_ms_type = va_ms.get("Type", None)
+            if str(va_ms_type) not in valid_multiple_scattering_methods:
+                raise ValueError("MultipleScatteringCorrection.Type is invalid: {}".format(va_ms_type))
+            #
+            if va_abs_type is None:
+                if va_ms_type is None:
+                    logging.warning("skipping absorption and multiple scattering correction for normalization.")
+                else:
+                    raise ValueError("multiple scattering correction requires absorption correction.")
+            elif va_abs_type == "Mayers":
+                if va_ms_type == "Carpenter":
+                    raise ValueError("Carpenter multiple scattering correction is incompatible with Mayers absorption correction.")
+                else:
+                    pass
+            elif va_abs_type == "Carpenter":
+                if va_ms_type == "Mayers":
+                    raise ValueError("Mayers multiple scattering correction is incompatible with Carpenter absorption correction.")
+                else:
+                    pass
+            else:
+                logging.info(f"[Normalization] will use {va_abs_type} for absorption and {va_ms_type} for multiple scattering")


### PR DESCRIPTION
- Original Gitlab User Story: PD290

This PR introduces the following changes:
- Validation of the input JSON configuration file is extended and isolated to a separate module.
- The background calculation for sample and vanadium are properly scaled with corresponding [effective] absorption correction factor prior to background subtraction
- Additional documentation is added to help future developer understand the physics behind the correction
- The absorption correction factors are now either first order absorption correction (without multiple scattering, convention route) or effective absorption correction factors (with multiple scattering).
- Section related to auto caching is added as comments (i.e. not enabled).
  - The caching is handled by the Mantid side, and should not be enable until the Mantid side implementation is done. 