### PR TITLE
Switches to nightly mantid channel in tox conda channels

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ python =
 skip_install = True
 conda_channels =
     conda-forge
-    mantid
+    mantid/label/nightly
 conda_deps =
     mantid-framework
 deps =
@@ -34,7 +34,7 @@ commands = bandit -r total_scattering/ -x total_scattering/_version.py
 skip_install = True
 conda_channels =
     conda-forge
-    mantid
+    mantid/label/nightly
 conda_deps =
     mantid-framework
 deps =


### PR DESCRIPTION
Fixes the mantid framework version pulled during tox testing.

Merging this into your branch to fix PR #113 
