### PR TITLE
fix self scattering level bug and change readme file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,11 +157,12 @@ can execute the command below to use the local Mantid build to work with the
 local version of `mantidtotalscattering`,
 
 ```bash
-MANTID-DEVELOPER_ENV_LOCATION/bin/python total_scattering/cli.py INPUT_JSON_FILE
+conda activate mantid-developer
+python MANTID_REPO_DIR/build/bin/AddPythonPath.py
+python total_scattering/cli.py INPUT_JSON_FILE
 ```
 
-where `MANTID-DEVELOPER_ENV_LOCATION` can be obtained via `conda env list` to
-list out all conda environments and their corresponding location.
+where `MANTID_REPO_DIR` refers to the full path of the `mantid` repo directory.
 
 The second way we can try is to launch `mantidtotalscattering` from within
 `mantidworkbench`. To do this, again, assuming we are located in the main
@@ -209,8 +210,7 @@ this, follow the steps below,
 
 5. python setup.py develop
 
-where `MANTID-DEVELOPER_ENV_LOCATION` can be obtained via `conda env list` to
-list out all conda environments and their corresponding location.
+where `MANTID_REPO_DIR` refers to the full path of the `mantid` repo directory.
 
 Tests
 ===========================================================

--- a/tests/total_scattering/test_normalizations.py
+++ b/tests/total_scattering/test_normalizations.py
@@ -79,11 +79,11 @@ class TestNormalizations(unittest.TestCase):
         q_ranges = ts.get_self_scattering_level(config, 45.0)
         offset, slope = calculate_and_apply_fitted_levels(self.s_of_q,
                                                           q_ranges)
-        offsets = {2: -27.71581, 3: 0.20049, 4: 0.47820, 5: 0.22630}
+        offsets = {2: 1.99763, 3: 0.42107, 4: 0.24137, 5: 0.20591}
         slopes = {2: 1.56386, 3: 0.00882, 4: -0.006766, 5: -0.000582}
 
-        print("Debugging -> ", offset)
-        print("Debugging -> ", slope)
+        print("[Info] Fitted offsets => ", offset)
+        print("[Info] Fitted slopes => ", slope)
 
         for key in q_ranges:
             self.assertTrue(np.allclose(offsets[key], offset[key],

--- a/total_scattering/reduction/normalizations.py
+++ b/total_scattering/reduction/normalizations.py
@@ -91,7 +91,7 @@ def calculate_and_apply_fitted_levels(
         offset_tmp = mtd['tmp_wks_fitted_Parameters'].row(0)['Value']
         slope_tmp = mtd['tmp_wks_fitted_Parameters'].row(1)['Value']
 
-        offset[key] = offset_tmp
+        offset[key] = offset_tmp + (value[0] + value[1]) * slope_tmp / 2.0
         slope[key] = slope_tmp
 
         DeleteWorkspace(tmp_wks)

--- a/total_scattering/reduction/total_scattering_reduction.py
+++ b/total_scattering/reduction/total_scattering_reduction.py
@@ -1788,7 +1788,8 @@ def TotalScatteringReduction(config: dict = None):
 
     # Print log information
     material = Material(sam_corrected)
-    log_file_out = open(os.path.join(os.path.abspath(OutputDir), 'README.LOG'),
+    log_file_out = open(os.path.join(os.path.abspath(OutputDir),
+                                     f'{title}.log'),
                         "w")
     sep_line = "==============================="
     sep_line += "=================================\n"


### PR DESCRIPTION
1. Fix the issue with the `Development` section in readme file.

2. Fix the issue with the self scattering level correction.

3. Change the `README.LOG` file name to be specific to each MTS run, by using the title as the stem name.