### PR TITLE
solve the vanadium bkg cache issue

### DIFF
--- a/total_scattering/file_handling/load.py
+++ b/total_scattering/file_handling/load.py
@@ -83,10 +83,13 @@ def load(ws_name, input_files, group_wksp,
         hash_obj = hashlib.sha256(str(run_list).encode())
         hash_str = hash_obj.hexdigest()
         short_hash_str = base64.urlsafe_b64encode(hash_str.encode()).decode()[:12]
+
+        cache_sf_bn = f"{instr_name}_mts_summed_"
         if auto_red:
-            cache_sf_bn = f"{instr_name}_mts_summed_{short_hash_str}_sgb.nxs"
+            cache_sf_bn += f"{short_hash_str}_sgb"
         else:
-            cache_sf_bn = f"{instr_name}_mts_summed_{short_hash_str}.nxs"
+            cache_sf_bn += f"{short_hash_str}"
+        cache_sf_bn += f"_{ws_name}.nxs"
         if ipts is not None:
             cache_sf_fn = os.path.join("/" + facility,
                                        instr_name,
@@ -105,10 +108,11 @@ def load(ws_name, input_files, group_wksp,
                 if run == "-1":
                     cache_f_exist = False
                 else:
+                    cache_f_bn = f"{instr_name}_{run}"
                     if auto_red:
-                        cache_f_bn = f"{instr_name}_{run}_mts_no_subg_sgb.nxs"
+                        cache_f_bn += f"_mts_no_subg_sgb_{ws_name}.nxs"
                     else:
-                        cache_f_bn = f"{instr_name}_{run}_mts_no_subg.nxs"
+                        cache_f_bn += f"_mts_no_subg_{ws_name}.nxs"
                     if ipts is not None:
                         cache_f_fn = os.path.join("/" + facility,
                                                   instr_name,
@@ -136,10 +140,6 @@ def load(ws_name, input_files, group_wksp,
                         OutputWorkspace=wksp_tmp,
                         Target="MomentumTransfer",
                         EMode="Elastic")
-                    Rebin(
-                        InputWorkspace=wksp_tmp,
-                        OutputWorkspace=wksp_tmp,
-                        Params=qparams)
                     if ipts is not None:
                         SaveNexusProcessed(
                             InputWorkspace=wksp_tmp,
@@ -164,7 +164,8 @@ def load(ws_name, input_files, group_wksp,
             if run == "-1":
                 cache_f_exist = False
             else:
-                cache_f_bn = f"{instr_name}_{run}_mts_subg.nxs"
+                cache_f_bn = f"{instr_name}_{run}_mts_subg"
+                cache_f_bn += f"_{ws_name}.nxs"
                 cache_f_fn = os.path.join("/" + facility,
                                           instr_name,
                                           ipts,
@@ -266,6 +267,12 @@ def load(ws_name, input_files, group_wksp,
         InputWorkspace=ws_name,
         OutputWorkspace=ws_name,
         RecalculatePCharge=True)
+
+    if group_wksp is None:
+        Rebin(
+            InputWorkspace=ws_name,
+            OutputWorkspace=ws_name,
+            Params=qparams)
 
     if geometry and chemical_formula and mass_density:
         set_sample(ws_name, geometry, chemical_formula, mass_density)

--- a/total_scattering/reduction/total_scattering_reduction.py
+++ b/total_scattering/reduction/total_scattering_reduction.py
@@ -578,11 +578,11 @@ def TotalScatteringReduction(config: dict = None):
         van_ps_hb = van_ps.get("HighBackground", True)
         van_ps_pp_tol = van_ps.get("PeakPositionTolerance", 0.01)
     else:
-        van_ps_fwhm = 7
+        van_ps_fwhm = 10
         van_ps_tol = 4
         van_ps_bkg_type = "Quadratic"
         van_ps_hb = True
-        van_ps_pp_tol = 0.01
+        van_ps_pp_tol = 0.02
 
     # Create Nexus file basenames
     sample['Runs'] = expand_ints(sample['Runs'])


### PR DESCRIPTION
With the new implementation, we were trying to cache all the single runs for all the relevant measurements such as sample+container, container, container background, vanadium, and vanadium background. Then next time when trying to process any single run that was previously processed (mainly, align and focus), we will try to load in the existing cache for speeding things up. In most cases, this work fine. But there was an issue regarding the container background caching. When we process the container background, we have to apply the absorption workspace relevant to either sample or container. But when we process the vanadium background (which is the same run number as the container background), we have to use the vanadium absorption workspace. So, even the run number could be shared, the actual cache workspace cannot be shared. This issue has been addressed in this new version.