### PR TITLE
fix cache file name issue

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ["3.10"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,7 +1,7 @@
 name: mantid_total_scattering_ci
 
 env:
-  PYTHON_MAIN_VERSION: 3.8
+  PYTHON_MAIN_VERSION: 3.10
 
 on:
   workflow_dispatch:
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8"]
+        python-version: ["3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Conda install deps
         shell: bash -l {0}
         run: |
-          conda install mantid
+          conda install mantidworkbench
           conda install --file requirements-conda.txt --file requirements-dev-conda.txt
           pip install tox-gh-actions==2.12.0
           pip install https://oncat.ornl.gov/packages/pyoncat-1.5.1-py3-none-any.whl

--- a/Pipfile
+++ b/Pipfile
@@ -14,4 +14,4 @@ tox = "*"
 [packages]
 
 [requires]
-python_version = "3.8"
+python_version = "3.10"

--- a/conda.recipe/mantid-total-scattering/meta.yaml
+++ b/conda.recipe/mantid-total-scattering/meta.yaml
@@ -13,14 +13,14 @@ build:
 
 requirements:
   build:
-    - mantid>6.6
+    - mantidworkbench>6.6
     - python
     - setuptools
     - matplotlib
     - scikit-learn
 
   run:
-    - {{ pin_compatible("mantid", max_pin="x.x") }}
+    - {{ pin_compatible("mantidworkbench", max_pin="x.x") }}
     - python
     - matplotlib
     - scikit-learn

--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -1,2 +1,1 @@
-matplotlib
 scikit-learn

--- a/requirements-dev-conda.txt
+++ b/requirements-dev-conda.txt
@@ -4,5 +4,4 @@ pytest
 pytest-cov
 tox
 tox-conda
-matplotlib
 scikit-learn

--- a/total_scattering/autogrouping/autogrouping.py
+++ b/total_scattering/autogrouping/autogrouping.py
@@ -445,8 +445,9 @@ def autogrouping(config):
             count_dict[item] = ul_counts[ii]
         removed_group = list()
         for ii in range(len(labels_dup)):
-            if count_dict[labels_dup[ii]] == 1:
-                removed_group.append(labels_dup[ii])
+            if count_dict[labels_dup[ii]] < 20:
+                if labels_dup[ii] not in removed_group:
+                    removed_group.append(labels_dup[ii])
                 labels_dup[ii] = -1
         for ii in range(len(labels_dup)):
             num_removed = 0

--- a/total_scattering/file_handling/load.py
+++ b/total_scattering/file_handling/load.py
@@ -43,6 +43,7 @@ def load(ws_name, input_files, group_wksp,
          absorption_wksp='', out_group_dict=None,
          qparams='0.01,0.001,40.0', auto_red=False,
          group_all_file=None,
+         sam_files=None,
          **align_and_focus_args):
     '''Routine for loading workspace'''
 
@@ -89,7 +90,7 @@ def load(ws_name, input_files, group_wksp,
             cache_sf_bn += f"{short_hash_str}_sgb"
         else:
             cache_sf_bn += f"{short_hash_str}"
-        cache_sf_bn += f"_{ws_name}.nxs"
+        cache_sf_bn += f"_{ws_name}_{sam_files.split(',')[0]}.nxs"
         if ipts is not None:
             cache_sf_fn = os.path.join("/" + facility,
                                        instr_name,
@@ -110,9 +111,11 @@ def load(ws_name, input_files, group_wksp,
                 else:
                     cache_f_bn = f"{instr_name}_{run}"
                     if auto_red:
-                        cache_f_bn += f"_mts_no_subg_sgb_{ws_name}.nxs"
+                        cache_f_bn += f"_mts_no_subg_sgb_{ws_name}"
+                        cache_f_bn += f"_{sam_files.split(',')[0]}.nxs"
                     else:
-                        cache_f_bn += f"_mts_no_subg_{ws_name}.nxs"
+                        cache_f_bn += f"_mts_no_subg_{ws_name}"
+                        cache_f_bn += f"_{sam_files.split(',')[0]}.nxs"
                     if ipts is not None:
                         cache_f_fn = os.path.join("/" + facility,
                                                   instr_name,
@@ -165,7 +168,8 @@ def load(ws_name, input_files, group_wksp,
                 cache_f_exist = False
             else:
                 cache_f_bn = f"{instr_name}_{run}_mts_subg"
-                cache_f_bn += f"_{ws_name}.nxs"
+                cache_f_bn += f"_{ws_name}"
+                cache_f_bn += f"_{sam_files.split(',')[0]}.nxs"
                 cache_f_fn = os.path.join("/" + facility,
                                           instr_name,
                                           ipts,

--- a/total_scattering/reduction/total_scattering_reduction.py
+++ b/total_scattering/reduction/total_scattering_reduction.py
@@ -984,7 +984,8 @@ def TotalScatteringReduction(config: dict = None):
                     WorkspaceName=grp_wksp.replace('_group', ''),
                     MakeGroupingWorkspace=True,
                     MakeCalWorkspace=False,
-                    MakeMaskWorkspace=False)
+                    MakeMaskWorkspace=False,
+                    TofMin=alignAndFocusArgs['TMin'])
         load_grouping = True
 
     # Setup the 6 bank method if no grouping specified
@@ -993,6 +994,11 @@ def TotalScatteringReduction(config: dict = None):
                                 GroupDetectorsBy='Group',
                                 OutputWorkspace=grp_wksp)
         alignAndFocusArgs['GroupingWorkspace'] = grp_wksp
+
+    if auto_red:
+        CreateGroupingWorkspace(InstrumentName=instr,
+                                GroupDetectorsBy='All',
+                                OutputWorkspace=grp_wksp)
 
     #################################################################
     # Load, calibrate and diffraction focus
@@ -1020,6 +1026,7 @@ def TotalScatteringReduction(config: dict = None):
         qparams=qparams,
         auto_red=auto_red,
         group_all_file=group_all_file,
+        sam_files=sam_scans,
         **alignAndFocusArgs)
     sample_title = "sample_and_container"
     if debug_mode:
@@ -1056,6 +1063,7 @@ def TotalScatteringReduction(config: dict = None):
         qparams=qparams,
         auto_red=auto_red,
         group_all_file=group_all_file,
+        sam_files=sam_scans,
         **alignAndFocusArgs)
     if debug_mode:
         save_banks(
@@ -1104,6 +1112,7 @@ def TotalScatteringReduction(config: dict = None):
                 qparams=qparams,
                 auto_red=auto_red,
                 group_all_file=group_all_file,
+                sam_files=sam_scans,
                 **alignAndFocusArgs)
             tmp = load(
                 'container_background_tmp',
@@ -1118,6 +1127,7 @@ def TotalScatteringReduction(config: dict = None):
                 qparams=qparams,
                 auto_red=auto_red,
                 group_all_file=group_all_file,
+                sam_files=sam_scans,
                 **alignAndFocusArgs)
             Minus(
                 LHSWorkspace=container_bg,
@@ -1137,6 +1147,7 @@ def TotalScatteringReduction(config: dict = None):
                 qparams=qparams,
                 auto_red=auto_red,
                 group_all_file=group_all_file,
+                sam_files=sam_scans,
                 **alignAndFocusArgs)
         if debug_mode:
             save_banks(
@@ -1168,6 +1179,7 @@ def TotalScatteringReduction(config: dict = None):
         qparams=qparams,
         auto_red=auto_red,
         group_all_file=group_all_file,
+        sam_files=sam_scans,
         **alignAndFocusArgs)
 
     vanadium_title = "vanadium_and_background"
@@ -1231,6 +1243,7 @@ def TotalScatteringReduction(config: dict = None):
             qparams=qparams,
             auto_red=auto_red,
             group_all_file=group_all_file,
+            sam_files=sam_scans,
             **alignAndFocusArgs)
 
         vanadium_bg_title = "vanadium_background"

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py38,lint,lint-security,coverage
 
 [gh-actions]
 python =
-  3.8: py38
+  3.10: py310
 
 [testenv]
 skip_install = True


### PR DESCRIPTION
This PR takes care of the following issues,

1. For the auto-grouping of pixels, pixels belonging to those groups with the number of members smaller than 20 will all be masked out.
2. The sample run number will be inserted into the cache file name to prevent the re-using of the wrong cache file.
3. The `TMin` parameter is passed to the `LoadDiffCal` algorithm to suppress the warning message when the `tzero` parameter is greater than 0.