### PR TITLE
pass in height info for abs pre-calc

### DIFF
--- a/total_scattering/file_handling/load.py
+++ b/total_scattering/file_handling/load.py
@@ -658,10 +658,22 @@ def create_absorption_wksp(filename, abs_method, geometry, material,
 
     # 2. calculate the absorption workspace (first order absorption) without
     #    calling to cache
-    abs_s, abs_c = absorptioncorrutils.calc_absorption_corr_using_wksp(
+    if "CacheDir" in align_and_focus_args:
+        if "BL11A:CS:ITEMS:HeightInContainer" not in mtd[donor_ws].run():
+            h_val = geometry["Height"]
+            mtd[donor_ws].run()["BL11A:CS:ITEMS:HeightInContainer"] = h_val
+        abs_s, abs_c = absorptioncorrutils.calc_absorption_corr_using_wksp(
             donor_ws,
             abs_method,
-            element_size=elementsize)
+            element_size=elementsize,
+            cache_dirs=align_and_focus_args["CacheDir"]
+        )
+    else:
+        abs_s, abs_c = absorptioncorrutils.calc_absorption_corr_using_wksp(
+            donor_ws,
+            abs_method,
+            element_size=elementsize
+        )
 
     if not (group_wksp_in is None or re_gen_group):
         if abs_s != "":


### PR DESCRIPTION
We were trying to implement the pre-calculation of absorption for `SNSPowderReduction`, we had to specify the cache directory as a parameter to the absorption calculation routine. From there, the absorption calculation will be cached internally instead of like what we do for MTS where the caching happens outside the util.

For the internal way of caching, the routine needs to figure out the cache file name using some log information for the sample which is more for the situation where the data is already available. For our pre-calculation purpose, we then have to pass in the sample height information explicitly.