### PR TITLE
separate conda build and push to anaconda

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -56,6 +56,13 @@ jobs:
           pip install coverage
           bash <(curl -s https://codecov.io/bash)
 
+      - name: Build conda package
+        shell: bash -l {0}
+        run: |
+          conda install -y anaconda-client conda-build conda-verify
+          cd conda.recipe/mantid-total-scattering
+          conda build --output-folder . -c neutrons -c oncat .
+
       - name: Deploy full package to Anaconda
         shell: bash -l {0}
         if: startsWith( github.ref, 'refs/tags/v')
@@ -63,9 +70,6 @@ jobs:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
           IS_RC: ${{ contains(github.ref, 'rc') }}
         run: |
-          conda install -y anaconda-client conda-build conda-verify
-          cd conda.recipe/mantid-total-scattering
-          conda build --output-folder . -c neutrons -c oncat .
           CONDA_LABEL="main"
           if [ "${IS_RC}" = "true" ]; then CONDA_LABEL="rc"; fi
           anaconda upload --label $CONDA_LABEL linux-64/*.tar.bz2
@@ -84,32 +88,32 @@ jobs:
           if [ "${IS_RC}" = "true" ]; then CONDA_LABEL="rc"; fi
           anaconda upload --label $CONDA_LABEL noarch/*.tar.bz2
 
-  trigger-deploy:
-    runs-on: ubuntu-22.04
-    needs: [linux]
-    # only trigger deploys from protected branches and tags
-    if: ${{ github.ref_protected || github.ref_type == 'tag' }}
-    steps:
-      - name: Determine Environment
-        uses: neutrons/branch-mapper@v2
-        id: conda_env_name
-        with:
-          prefix: mantidtotalscattering
-
-      - name: Trigger deploy
-        id: trigger
-        uses: eic/trigger-gitlab-ci@v2
-        with:
-          url: https://code.ornl.gov
-          token: ${{ secrets.GITLAB_TRIGGER_TOKEN }}
-          project_id: 7835
-          ref_name: main
-          variables: |
-            PLAY="update"
-            CONDA_ENV="${{ steps.conda_env_name.outputs.name }}"
-
-      - name: Annotate commit
-        uses: peter-evans/commit-comment@v2
-        with:
-          body: |
-            GitLab pipeline for ${{ steps.conda_env_name.outputs.name }} has been submitted for this commit: ${{ steps.trigger.outputs.web_url }}
+#  trigger-deploy:
+#    runs-on: ubuntu-22.04
+#    needs: [linux]
+#    # only trigger deploys from protected branches and tags
+#    if: ${{ github.ref_protected || github.ref_type == 'tag' }}
+#    steps:
+#      - name: Determine Environment
+#        uses: neutrons/branch-mapper@v2
+#        id: conda_env_name
+#        with:
+#          prefix: mantidtotalscattering
+#
+#      - name: Trigger deploy
+#        id: trigger
+#        uses: eic/trigger-gitlab-ci@v2
+#        with:
+#          url: https://code.ornl.gov
+#          token: ${{ secrets.GITLAB_TRIGGER_TOKEN }}
+#          project_id: 7835
+#          ref_name: main
+#          variables: |
+#            PLAY="update"
+#            CONDA_ENV="${{ steps.conda_env_name.outputs.name }}"
+#
+#      - name: Annotate commit
+#        uses: peter-evans/commit-comment@v2
+#        with:
+#          body: |
+#            GitLab pipeline for ${{ steps.conda_env_name.outputs.name }} has been submitted for this commit: ${{ steps.trigger.outputs.web_url }}


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->

Update the github action to separate our the conda package build.

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

Originally, we only build the conda package when a new tag is created, followed by pushing the conda package to anaconda. With this PR, we separate out the conda package build part so that every time a PR is made, the conda package will be built and if a new tag is created, the built conda package will be then be pushed to anaconda.