### PR TITLE
easy way for manually grouping and recaching

### DIFF
--- a/total_scattering/file_handling/load.py
+++ b/total_scattering/file_handling/load.py
@@ -44,6 +44,7 @@ def load(ws_name, input_files, group_wksp,
          qparams='0.01,0.001,40.0', auto_red=False,
          group_all_file=None,
          sam_files=None,
+         re_cache=False,
          **align_and_focus_args):
     '''Routine for loading workspace'''
 


### PR DESCRIPTION
# Description of the changes:

With the currently implementation for fast absorption correction, the way to specify a manual grouping is not straightforward - the configuration relies on the changing of a central configuration parameter, and it happens a lot when needs for different grouping for different data processing emerge simultaneously.

This PR is to fix this issue by introducing a logic at the parameter loading stage so that once a manual grouping file is specified, the reduction will fall back to the slow absorption correction, i.e., all absorption spectra for all pixels will be treated explicitly without any grouping.

Meanwhile, this PR introduces a flag to have a control over whether we want to redo the caching, i.e., ignore all the existing cache and re-save the processed files to cache, which means all the existing cache will be overwritten.